### PR TITLE
Move vscode dependency to non-dev dependencies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,11 +17,11 @@
 	"main": "./lib/main.js",
 	"typings": "./lib/main",
 	"devDependencies": {
-		"shx": "^0.3.1",
-		"vscode": "^1.1.18"
+		"shx": "^0.3.1"
 	},
 	"dependencies": {
-		"vscode-languageserver-protocol": "^3.10.0"
+		"vscode-languageserver-protocol": "^3.10.0",
+		"vscode": "^1.1.18"
 	},
 	"scripts": {
 		"prepare": "npm run update-vscode",


### PR DESCRIPTION
The vscode package is imported at runtime, for example here:

  codeConverter.ts:7:import * as code from 'vscode';

so I believe the vscode dependency should be in the non-dev section.

A way to reproduce a build failure due to this is to try to build a
Theia application only with the "@theia/editor" extension.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>